### PR TITLE
Added missing mongoose dependency to boilerplate

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
     "body-parser": "^1.18.1",
     "cors": "^2.8.4",
     "express": "^4.15.4",
+    "mongoose": "^5.12.7",
     "morgan": "^1.8.2",
     "nodemon": "^1.12.1"
   }


### PR DESCRIPTION
Aiming to fix 'MODULE_NOT_FOUND' on virgin clone/start